### PR TITLE
Faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,5 @@ dependencies:
     - curl https://raw.githubusercontent.com/remind101/docker-build/master/docker-build > /home/ubuntu/bin/docker-build
     - chmod +x /home/ubuntu/bin/docker-build
   override:
-    - docker-build build
-
-deployment:
-  hub: 
-    branch: /.*/
-    commands:
-      - docker-build push
-      - docker images
+    - docker-build
 ```

--- a/docker-build
+++ b/docker-build
@@ -27,6 +27,7 @@ download() {
   sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
   sudo chmod 0755 /usr/bin/docker
   sudo service docker start
+  sleep 10
   docker version
 }
 

--- a/docker-build
+++ b/docker-build
@@ -24,7 +24,9 @@ login() {
 
 # Downloads the most recent version, installs it and starts it.
 download() {
-  sudo service docker stop; sudo curl -L -o /usr/bin/docker "$DOCKER_URL"; sudo chmod 0755 /usr/bin/docker; sudo service docker start; true
+  sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
+  sudo chmod 0755 /usr/bin/docker
+  sudo service docker start
   docker version
 }
 

--- a/docker-build
+++ b/docker-build
@@ -2,7 +2,7 @@
 
 set -e
 
-DOCKER_URL="https://master.dockerproject.org/linux/amd64/docker-1.8.0-dev"
+DOCKER_URL="http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.0-circleci"
 
 # The docker repo.
 REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
@@ -32,7 +32,6 @@ download() {
 # Init downloads docker, starts it and logs in.
 init() {
   download
-  sleep 30
   login
 }
 

--- a/docker-build
+++ b/docker-build
@@ -16,10 +16,16 @@ usage() {
   exit 1
 }
 
+login() {
+  docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+}
+
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
   declare repo="$1" sha="$CIRCLE_SHA1" branch="$CIRCLE_BRANCH"
-  docker build --no-cache -t "$repo" .
+  login
+  docker pull "$repo"
+  docker build -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
   docker tag "$repo" "${repo}:${branch}"
 }
@@ -32,7 +38,7 @@ push() {
     usage
   fi
 
-  docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+  login
   docker push "$repo"
 }
 

--- a/docker-build
+++ b/docker-build
@@ -24,10 +24,7 @@ login() {
 
 # Downloads the most recent version, installs it and starts it.
 download() {
-  sudo service docker stop
-  sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
-  sudo chmod 0755 /usr/bin/docker
-  sudo service docker start
+  sudo service docker stop; sudo curl -L -o /usr/bin/docker "$DOCKER_URL"; sudo chmod 0755 /usr/bin/docker; sudo service docker start; true
 }
 
 # Init downloads docker, starts it and logs in.

--- a/docker-build
+++ b/docker-build
@@ -27,8 +27,6 @@ download() {
   sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
   sudo chmod 0755 /usr/bin/docker
   sudo service docker start
-  sleep 10
-  docker version
 }
 
 # Init downloads docker, starts it and logs in.

--- a/docker-build
+++ b/docker-build
@@ -26,7 +26,7 @@ login() {
 download() {
   sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
   sudo chmod 0755 /usr/bin/docker
-  sudo service docker start
+  docker -d
 }
 
 # Init downloads docker, starts it and logs in.

--- a/docker-build
+++ b/docker-build
@@ -49,7 +49,10 @@ case "$1" in
   "push")
     push "$REPO"
     ;;
-  *)
+  "help")
     usage
+    ;;
+  *)
+    build "$REPO" && push "$REPO"
     ;;
 esac

--- a/docker-build
+++ b/docker-build
@@ -25,6 +25,7 @@ login() {
 # Downloads the most recent version, installs it and starts it.
 download() {
   sudo service docker stop; sudo curl -L -o /usr/bin/docker "$DOCKER_URL"; sudo chmod 0755 /usr/bin/docker; sudo service docker start; true
+  docker version
 }
 
 # Init downloads docker, starts it and logs in.

--- a/docker-build
+++ b/docker-build
@@ -32,6 +32,7 @@ download() {
 # Init downloads docker, starts it and logs in.
 init() {
   download
+  sleep 30
   login
 }
 

--- a/docker-build
+++ b/docker-build
@@ -2,6 +2,8 @@
 
 set -e
 
+DOCKER_URL="https://master.dockerproject.org/linux/amd64/docker-1.8.0-dev"
+
 # The docker repo.
 REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 
@@ -20,10 +22,23 @@ login() {
   docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
 }
 
+# Downloads the most recent version, installs it and starts it.
+download() {
+  sudo service docker stop
+  sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
+  sudo chmod 0755 /usr/bin/docker
+  sudo service docker start
+}
+
+# Init downloads docker, starts it and logs in.
+init() {
+  download
+  login
+}
+
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
   declare repo="$1" sha="$CIRCLE_SHA1" branch="$CIRCLE_BRANCH"
-  login
   docker pull "${repo}:${branch}" # Pull the last build for this branch so we can use cached layers.
   docker build -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
@@ -38,11 +53,13 @@ push() {
     usage
   fi
 
-  login
   docker push "$repo"
 }
 
 case "$1" in
+  "init")
+    init
+    ;;
   "build")
     build "$REPO"
     ;;
@@ -53,6 +70,6 @@ case "$1" in
     usage
     ;;
   *)
-    build "$REPO" && push "$REPO"
+    init && build "$REPO" && push "$REPO"
     ;;
 esac

--- a/docker-build
+++ b/docker-build
@@ -26,7 +26,7 @@ login() {
 download() {
   sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
   sudo chmod 0755 /usr/bin/docker
-  sudo docker -d
+  sudo service docker start
 }
 
 # Init downloads docker, starts it and logs in.

--- a/docker-build
+++ b/docker-build
@@ -26,7 +26,7 @@ login() {
 download() {
   sudo curl -L -o /usr/bin/docker "$DOCKER_URL"
   sudo chmod 0755 /usr/bin/docker
-  docker -d
+  sudo docker -d
 }
 
 # Init downloads docker, starts it and logs in.

--- a/docker-build
+++ b/docker-build
@@ -39,7 +39,7 @@ init() {
 # pull an image tagged with the branch and fallback to "latest"
 pull() {
   declare repo="$1" branch="$CIRCLE_BRANCH"
-  docker pull "${repo}:${branch}" || docker pull "${repo}:latest"
+  docker pull "${repo}:${branch}" || docker pull "${repo}:latest" || true
 }
 
 # Build builds the docker image and tags it with the git sha and branch.

--- a/docker-build
+++ b/docker-build
@@ -27,7 +27,7 @@ build() {
   docker pull "${repo}:${branch}" # Pull the last build for this branch so we can use cached layers.
   docker build -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
-  docker tag "$repo" "${repo}:${branch}"
+  docker tag -f "$repo" "${repo}:${branch}" # Force tag because we pulled the last build for this branch.
 }
 
 # Push pushes all of the built docker images.

--- a/docker-build
+++ b/docker-build
@@ -24,7 +24,7 @@ login() {
 build() {
   declare repo="$1" sha="$CIRCLE_SHA1" branch="$CIRCLE_BRANCH"
   login
-  docker pull "$repo"
+  docker pull "${repo}:${branch}" # Pull the last build for this branch so we can use cached layers.
   docker build -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
   docker tag "$repo" "${repo}:${branch}"

--- a/docker-build
+++ b/docker-build
@@ -35,10 +35,17 @@ init() {
   login
 }
 
+# Pull attempts to pull the last built image for this branch. It will try to
+# pull an image tagged with the branch and fallback to "latest"
+pull() {
+  declare repo="$1" branch="$CIRCLE_BRANCH"
+  docker pull "${repo}:${branch}" || docker pull "${repo}:latest"
+}
+
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
   declare repo="$1" sha="$CIRCLE_SHA1" branch="$CIRCLE_BRANCH"
-  docker pull "${repo}:${branch}" # Pull the last build for this branch so we can use cached layers.
+  pull "$repo"
   docker build -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
   docker tag -f "$repo" "${repo}:${branch}" # Force tag because we pulled the last build for this branch.


### PR DESCRIPTION
This does a couple things in an attempt to make build + push faster:
1. When building, it will first pull the last build for the branch. We do this so that we have a solid cache of all the layers.
2. It builds without the `--no-cache` flag so that we're using cached layers from the pull.
3. Defaults to running both build + push so that in CI, we push as early as possible so the image can be deployed.

Closes https://github.com/remind101/docker-build/issues/2. Planning on running this branch on a couple of projects to start with, to make sure there's no issues.

**TODO**
- [x] Handle `docker pull <branch>` failure by pulling `master`, then `latest`.
- [ ] Don't delete this branch after merging.
