### PR TITLE
Tag docker images with git tags when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ It makes the following assumptions:
 1. Your docker registry repo and GitHub repo are the same (e.g. remind101/acme-inc on GitHub, remind101/acme-inc on Docker registry).
 2. You want to tag the docker image with the value of the `$CIRLE_SHA1` (git commit sha) and `$CIRCLE_BRANCH` (git branch).
 3. You're docker credentials are provided as `$DOCKER_EMAIL`, `$DOCKER_USER`, `$DOCKER_PASS`
+4. If you're using a different registry than DockerHub then `$DOCKER_REGISTRY` is set. Please see [this blog post][private_registry] on the format of the registry url.
 
 ## Usage
 
@@ -54,9 +55,11 @@ dependencies:
     - docker-build build
 
 deployment:
-  hub: 
+  hub:
     branch: /.*/
     commands:
       - docker-build push
       - docker images
 ```
+
+[private_registry]: https://blog.docker.com/2013/07/how-to-use-your-own-registry/

--- a/docker-build
+++ b/docker-build
@@ -19,9 +19,13 @@ usage() {
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
   declare repo="$1" sha="$CIRCLE_SHA1" branch="$CIRCLE_BRANCH"
+  declare tag=`git describe --tags --exact-match $CIRCLE_SHA1 2>/dev/null`
   docker build --no-cache -t "$repo" .
   docker tag "$repo" "${repo}:${sha}"
   docker tag "$repo" "${repo}:${branch}"
+  if [ -n "$tag" ]; then
+    docker tag "$repo" "${repo}:${tag}"
+  fi
 }
 
 # Push pushes all of the built docker images.

--- a/docker-build
+++ b/docker-build
@@ -30,7 +30,11 @@ build() {
 
 # Push pushes all of the built docker images.
 push() {
-  declare repo="$1"
+  declare repo="$1" registry="$2"
+
+  if [ -n "$registry" ]; then
+    repo=$registry/$repo
+  fi
 
   if [ -z "$DOCKER_EMAIL" ] || [ -z "$DOCKER_USER" ] || [ -z "$DOCKER_PASS" ]; then
     usage
@@ -45,7 +49,7 @@ case "$1" in
     build "$REPO"
     ;;
   "push")
-    push "$REPO"
+    push "$REPO" "$DOCKER_REGISTRY"
     ;;
   *)
     usage


### PR DESCRIPTION
This pull request adds two features: 
- Tag docker images with git tags as well when they are present
- Allow to use a different docker registry (other than DockerHub)
