### PR TITLE
Update docker image and add git

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
 jobs:
   docker_image:
     docker:
-      - image: remind101/docker-build:dd4aff6469c6b8db8b5a9f65e4ff0635672267a2
+      - image: remind101/docker-build@sha256:eb1001b5d8efd946039c4b0ac181640970230f4e3f69e49c5359ba70fde1a926
     steps:
       - checkout
       - setup_remote_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
-FROM alpine:3.2
+FROM docker:17.05.0-ce-git
 MAINTAINER Christophe Furmaniak <christophe.furmaniak@gmail.com>
 
-RUN apk add --update curl bash \
-  && curl -L https://download.docker.com/linux/static/stable/x86_64/docker-17.03.1-ce.tgz > /tmp/docker.tgz \
-  && tar xzvf /tmp/docker.tgz \
-  && cp docker/docker /usr/bin/docker \
-  && rm -rf /tmp/docker* \
-  && rm -rf /var/cache/apk/*
+ENTRYPOINT /bin/sh
 
-ADD docker-build /usr/local/bin/docker-build
+COPY docker-build /usr/local/bin/docker-build

--- a/docker-build
+++ b/docker-build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
When building the docker image for frontend in CircleCI, the checkout step takes two minutes and gives a warning: 
```
Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.
```
https://circleci.com/gh/remind101/r101-frontend/44300

When doing the checkout in other containers, it's around 15 seconds. https://circleci.com/gh/remind101/r101-frontend/44297

This fixes it by using the official docker image with git as the base. https://hub.docker.com/_/docker/ It uses Alpine so should still be small. 

One question: What should I name and tag this image when pushing to dockerhub? I cannot find a `docker-build` repo in our dockerhub. 

For some reason this file already existed in the circle-2.0 branch, but not in master. Should I make the PR to that branch instead? https://github.com/remind101/docker-build/blob/circle-2.0/Dockerfile
