### PR TITLE
NO_EXTRA_TAGS: Optionally create less tags in docker hub.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,10 @@ workflows:
 jobs:
   docker_image:
     docker:
-      - image: remind101/docker-build@sha256:72b3e45ca70b576a9722f70b2e188c75533d98040508be6a550101b4fb430543
-    environment: 
-      NO_EXTRA_TAGS: "true"
+      - image: remind101/docker-build@sha256:b2b7a582c803e21a835c496de269f49fbc069d21b21000cfd44e089241483c75
+      # example on how to avoid creating branch and commit tags in docker hub.
+      # environment: 
+      #   NO_EXTRA_TAGS: "true"
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,9 @@ workflows:
 jobs:
   docker_image:
     docker:
-      - image: remind101/docker-build@sha256:eb1001b5d8efd946039c4b0ac181640970230f4e3f69e49c5359ba70fde1a926
+      - image: remind101/docker-build@sha256:72b3e45ca70b576a9722f70b2e188c75533d98040508be6a550101b4fb430543
+    environment: 
+      NO_EXTRA_TAGS: "true"
     steps:
       - checkout
       - setup_remote_docker

--- a/docker-build
+++ b/docker-build
@@ -11,6 +11,13 @@ else
   exit 1
 fi
 
+if [[ -n "$NO_EXTRA_TAGS" ]]
+then
+    extra_tags=false
+else
+    extra_tags=true
+fi
+
 # Usage prints the help for this command.
 usage() {
   >&2 echo "Usage:"
@@ -37,7 +44,12 @@ pull() {
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
   local repo="$1" cache="$2"
-  docker build --cache-from "$cache" -t "$repo" -t "$repo:$SHA" -t "$repo:$BRANCH" .
+  if [ "$extra_tags" = true ];
+    then
+      docker build --cache-from "$cache" -t "$repo" -t "$repo:$SHA" -t "$repo:$BRANCH" .
+  else
+      docker build --cache-from "$cache" -t "$repo" .
+  fi
 }
 
 # Push pushes all of the built docker images.


### PR DESCRIPTION
NO_EXTRA_TAGS: Optionally create less tags in docker hub.

I want to be able to build docker images for the stacks repo, but I
don't want long lived tags hosted in docker hub.
