### PR TITLE
Add the commit ID and branch as build args to the Docker build

### DIFF
--- a/docker-build
+++ b/docker-build
@@ -53,7 +53,7 @@ build() {
   else
       tag_flags="-t $repo"
   fi
-  docker build --cache-from "$cache" $tag_flags .
+  docker build --build-arg GIT_COMMIT=$SHA --build-arg GIT_BRANCH=$BRANCH --cache-from "$cache" $tag_flags .
 }
 
 # Push pushes all of the built docker images.


### PR DESCRIPTION
I have a Dockerfile which jumps through some weird hoops to copy and then use the commit ID from the workspace into the Docker container.  I'd like to simplify the Dockerfile by having the commit be passed as a build arg.  However, the current CircleCI build and push mechanism doesn't allow arbitrary build args.  While that might be a desirable feature, a simpler approach would be to allow the (already in-use) SHA and BRANCH to be made available to the `docker build` command for Dockerfiles to use or not use as they see fit.  