### PR TITLE
Add support for buildkit and multi-stage builds, add shellcheck linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,20 @@ workflows:
   version: 2
   build:
     jobs:
-      - docker_image
+      - lint
+      - docker_image:
+          requires:
+            - lint
 
 jobs:
+  lint:
+    docker:
+      - image: alpine
+    steps:
+      - checkout
+      - run: apk add make shellcheck
+      - run: make lint
+
   docker_image:
     docker:
       - image: remind101/docker-build@sha256:b2b7a582c803e21a835c496de269f49fbc069d21b21000cfd44e089241483c75

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM docker:17.05.0-ce-git
-MAINTAINER Christophe Furmaniak <christophe.furmaniak@gmail.com>
+FROM docker:19.03-git
 
 ENTRYPOINT /bin/sh
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: lint
+lint:
+	shellcheck docker-build

--- a/README.md
+++ b/README.md
@@ -51,3 +51,24 @@ jobs:
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run: docker-build
 ```
+
+#### BuildKit Support
+
+To build with BuildKit and leverage improvements to `--cache-from` and inline
+cache metadata, set `DOCKER_BUILDKIT=1` in the environment and make sure you're
+using at least Docker 19.03:
+
+```yml
+jobs:
+  docker_image:
+    docker:
+      - image: remind101/docker-build
+    environment:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 19.03.13
+      - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
+      - run: docker-build
+```

--- a/docker-build
+++ b/docker-build
@@ -1,33 +1,42 @@
 #!/bin/sh
+# shellcheck shell=dash
 
 set -e
 
-if [ ! -z "$CIRCLECI" ]; then
-  REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
-  BRANCH="$CIRCLE_BRANCH"
-  SHA="$CIRCLE_SHA1"
-else
-  >&2 echo "This script only works on CircleCI right now."
-  exit 1
-fi
-
-if [[ -n "$NO_EXTRA_TAGS" ]]
-then
-    extra_tags=false
-else
-    extra_tags=true
-fi
-
 # Usage prints the help for this command.
 usage() {
-  >&2 echo "Usage:"
-  >&2 echo "    docker-build command"
-  >&2 echo ""
-  >&2 echo "Commands:"
-  >&2 echo "    pull   Attempt to pull the latest cache tag to build a layer cache"
-  >&2 echo "    build  Build a docker image from this repo and tag it with the git sha and branch"
-  >&2 echo "    push   Push the built image to the docker registry."
-  exit 1
+  >&2 cat <<EOF
+Usage:
+    docker-build [OPTIONS]
+    docker-build COMMAND [OPTIONS]
+
+Docker CLI wrapper that injects defaults for a more consistent
+CI process. Currently only works in CircleCI.
+
+Running docker-build with no COMMAND will do build-with-cache
+and then push automatically
+
+Any OPTIONS specified will be passed to 'docker build.
+
+Commands:
+    pull              Attempt to pull the latest cache tag to build a layer cache
+    build             Build a docker image from this repo and tag it with the git sha and branch
+    build-with-cache  Build with automatic --cache-from
+    push              Push the built image to the docker registry.
+
+Examples:
+    Basic usage:
+      $ docker-build
+
+    Build, but don't tag with branch and SHA1 tags:
+      $ NO_EXTRA_TAGS=1 docker-build build
+
+    Build and push an image with a multi-stage Dockerfile:
+      $ docker-build --target main
+
+    Build with buildkit (Docker >= 19.03):
+      $ DOCKER_BUILDKIT=1 docker-build
+EOF
 }
 
 # Performs a docker pull, and outputs the image reference to stdout if successfull
@@ -38,22 +47,61 @@ docker_pull() {
 
 pull() {
   local repo="$1"
-  docker_pull "$repo:$BRANCH" || docker_pull "$repo:master" || docker_pull "$repo:latest" || echo "$repo"
+  docker_pull "$repo:$BRANCH" \
+    || docker_pull "$repo:master" \
+    || docker_pull "$repo:latest" \
+    || echo "$repo"
 }
 
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
-  local repo="$1" cache="$2"
+  local repo="$1"
+  shift
+  args=""
   if [ "$extra_tags" = true ];
     then
-      tag_flags="-t $repo -t $repo:$SHA -t $repo:$BRANCH"
+      args="-t $repo -t $repo:$SHA -t $repo:$BRANCH"
   elif [ "$BRANCH" = "master" ];
     then
-      tag_flags="-t $repo -t $repo:$BRANCH"
+      args="-t $repo -t $repo:$BRANCH"
   else
-      tag_flags="-t $repo"
+      args="-t $repo"
   fi
-  docker build --build-arg GIT_COMMIT=$SHA --build-arg GIT_BRANCH=$BRANCH --cache-from "$cache" $tag_flags .
+  if [ "$DOCKER_BUILDKIT" = "1" ]; then
+    # Always include BuildKit inline cache when BuildKit is enabled, this
+    # allows --cache-from to work for multi-stage builds.
+    # BuildKit's default progress output is nice in interactive terminals but
+    # not so much in CI where we want simple sequential logs, so we also always
+    # set progress to plain with BuildKit.
+    args="$args --build-arg BUILDKIT_INLINE_CACHE=1 --progress plain"
+  fi
+
+  # Quoting $args will break this since ash doesn't support field splitting on
+  # anything other than "$@" - disabling shellcheck so that we don't get a
+  # warning.
+  # shellcheck disable=SC2086
+  docker build \
+    --build-arg "GIT_COMMIT=$SHA" \
+    --build-arg "GIT_BRANCH=$BRANCH" \
+    $args \
+    "$@" \
+    .
+}
+
+build_with_cache() {
+  local repo="$1"
+  shift
+  if [ "$DOCKER_BUILDKIT" = "1" ]; then
+    build "$repo" \
+      --cache-from "$repo:$BRANCH" \
+      --cache-from "$repo:master" \
+      --cache-from "$repo:latest" \
+      "$@"
+  else
+    build "$repo" \
+      --cache-from "$(pull "$repo")" \
+      "$@"
+  fi
 }
 
 # Push pushes all of the built docker images.
@@ -64,12 +112,49 @@ push() {
 
 run() {
   local repo="$1"
-  build "$repo" "$(pull "$repo")" && push "$repo"
+  shift
+  build_with_cache "$repo" "$@" && push "$repo"
 }
 
+# Main -------------------------------------------------
+
 case "$1" in
+  help|-h|--help) usage; exit 1 ;;
+esac
+
+if [ -n "$CIRCLECI" ]; then
+  REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+  BRANCH="$CIRCLE_BRANCH"
+  SHA="$CIRCLE_SHA1"
+else
+  >&2 echo "This script only works on CircleCI right now."
+  exit 1
+fi
+
+if [ "$DOCKER_BUILDKIT" = 1 ]; then
+  docker_version="$(docker version -f "{{.Server.Version}}")"
+  docker_version_maj="$(echo "$docker_version" | cut -d'.' -f 1)"
+  docker_version_min="$(echo "$docker_version" | cut -d'.' -f 2)"
+  if [ "$docker_version_maj" -lt 19 ] \
+    || { [ "$docker_version_maj" -eq 19 ] && [ "$docker_version_min" -lt 3 ]; }; then
+    >&2 echo "Docker engine version ${docker_version} is too old, must be >= 19.03 to use buildkit"
+    exit 1
+  fi
+fi
+
+if [ -n "$NO_EXTRA_TAGS" ]
+then
+    extra_tags=false
+else
+    extra_tags=true
+fi
+
+
+cmd="$1"
+case "$cmd" in
   pull) pull "$REPO" ;;
-  build) build "$REPO" ;;
+  build) shift; build "$REPO" "$@" ;;
+  build-with-cache) shift; build_with_cache "$REPO" "$@" ;;
   push) push "$REPO" ;;
-  *) run "$REPO" ;;
+  *) run "$REPO" "$@" ;;
 esac

--- a/docker-build
+++ b/docker-build
@@ -14,15 +14,29 @@ Docker CLI wrapper that injects defaults for a more consistent
 CI process. Currently only works in CircleCI.
 
 Running docker-build with no COMMAND will do build-with-cache
-and then push automatically
+and then push automatically.
 
-Any OPTIONS specified will be passed to 'docker build.
+Any OPTIONS specified will be passed to 'docker build' (if applicable).
 
 Commands:
     pull              Attempt to pull the latest cache tag to build a layer cache
-    build             Build a docker image from this repo and tag it with the git sha and branch
+    build             Build a docker image from this repo and tag it with the git SHA1 and branch
     build-with-cache  Build with automatic --cache-from
-    push              Push the built image to the docker registry.
+    push              Push the built image to the docker registry
+
+Tags:
+    The following tags will be built and pushed by default:
+      \$REPO:\$SHA1
+      \$REPO:\$BRANCH
+      \$REPO:latest
+
+    If NO_EXTRA_TAGS is set, only "latest" will be used, unless the branch is
+    "master", in which case it will also tag "master".
+
+    Cache will be used following tags if they exist:
+      \$REPO:\$BRANCH
+      \$REPO:master
+      \$REPO:latest
 
 Examples:
     Basic usage:
@@ -46,27 +60,18 @@ docker_pull() {
 }
 
 pull() {
-  local repo="$1"
-  docker_pull "$repo:$BRANCH" \
-    || docker_pull "$repo:master" \
-    || docker_pull "$repo:latest" \
-    || echo "$repo"
+  docker_pull "$REPO:$BRANCH" \
+    || docker_pull "$REPO:master" \
+    || docker_pull "$REPO:latest" \
+    || echo "$REPO"
 }
 
 # Build builds the docker image and tags it with the git sha and branch.
 build() {
-  local repo="$1"
-  shift
-  args=""
-  if [ "$extra_tags" = true ];
-    then
-      args="-t $repo -t $repo:$SHA -t $repo:$BRANCH"
-  elif [ "$BRANCH" = "master" ];
-    then
-      args="-t $repo -t $repo:$BRANCH"
-  else
-      args="-t $repo"
-  fi
+  local args=""
+  for tag in $TAGS; do
+    args="$args -t $REPO:$tag"
+  done
   if [ "$DOCKER_BUILDKIT" = "1" ]; then
     # Always include BuildKit inline cache when BuildKit is enabled, this
     # allows --cache-from to work for multi-stage builds.
@@ -89,31 +94,28 @@ build() {
 }
 
 build_with_cache() {
-  local repo="$1"
-  shift
   if [ "$DOCKER_BUILDKIT" = "1" ]; then
-    build "$repo" \
-      --cache-from "$repo:$BRANCH" \
-      --cache-from "$repo:master" \
-      --cache-from "$repo:latest" \
+    build \
+      --cache-from "$REPO:$BRANCH" \
+      --cache-from "$REPO:master" \
+      --cache-from "$REPO:latest" \
       "$@"
   else
-    build "$repo" \
-      --cache-from "$(pull "$repo")" \
+    build \
+      --cache-from "$(pull)" \
       "$@"
   fi
 }
 
 # Push pushes all of the built docker images.
 push() {
-  local repo="$1"
-  docker push "$repo"
+  for tag in $TAGS; do
+    docker push "$REPO:$tag"
+  done
 }
 
 run() {
-  local repo="$1"
-  shift
-  build_with_cache "$repo" "$@" && push "$repo"
+  build_with_cache "$@" && push
 }
 
 # Main -------------------------------------------------
@@ -142,19 +144,26 @@ if [ "$DOCKER_BUILDKIT" = 1 ]; then
   fi
 fi
 
-if [ -n "$NO_EXTRA_TAGS" ]
-then
-    extra_tags=false
+if [ -n "$NO_EXTRA_TAGS" ]; then
+  if [ "$BRANCH" = "master" ]; then
+    TAGS="$BRANCH latest"
+  else
+    TAGS="latest"
+  fi
 else
-    extra_tags=true
+  TAGS="$SHA $BRANCH latest"
 fi
-
 
 cmd="$1"
 case "$cmd" in
-  pull) pull "$REPO" ;;
-  build) shift; build "$REPO" "$@" ;;
-  build-with-cache) shift; build_with_cache "$REPO" "$@" ;;
-  push) push "$REPO" ;;
-  *) run "$REPO" "$@" ;;
+  pull)
+    shift; pull ;;
+  build)
+    shift; build "$@" ;;
+  build-with-cache)
+    shift; build_with_cache "$@" ;;
+  push)
+    shift; push ;;
+  *)
+    run "$@" ;;
 esac


### PR DESCRIPTION
Change summary:
- Update base image to Docker 19.03
- Pass through docker-build arguments to `docker build`, mostly so
  `--target` can be passed for multi-stage builds
- When `DOCKER_BUILDKIT=1`, modify the build command to do the following:
    - Pass `--build-arg BUILDKIT_INLINE_CACHE=1` so that images include
      cache metadata
    - Directly include additional `--cache-from` arguments
    - Skip `docker pull` since it is no longer necessary for
      `--cache-from` images that have inline buildkit cache metadata
- Add check to abort if `DOCKER_BUILDKIT=1` but the Docker engine is
  outdated
- Add help (or -h|--help) command to print usage, update usage
- Lint script using `shellcheck`

Testing
- [x] Check compatibility of Docker CLI client (`19.03`) with default Docker Engine in CircleCI (`17.09.0-ce`) to make sure this will work if the user doesn't specify a `version` in `setup_remote_docker`
https://app.circleci.com/pipelines/github/remind101/r101-router/178/workflows/e3014281-2e4c-4fa4-99f9-45357386f6fb/jobs/3569
- [x] Verify BuildKit functionality works as expected
https://app.circleci.com/pipelines/github/remind101/r101-router/177/workflows/2b44d6f4-7140-4272-8626-bacb95b2d151/jobs/3567