### PR TITLE
Add docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM docker:19.03-git
 
 ENTRYPOINT /bin/sh
 
-RUN apk add --update \
+RUN apk --no-cache add \
+    docker-compose \
     make
 
 COPY docker-build /usr/local/bin/docker-build


### PR DESCRIPTION
It's nice to be able to use this image for running tests or other
commands in CI before actually using the build script. Some of our repos
have (or could have!) simple docker-compose setups that will improve
parity between CI and local dev. This allows us to re-use this image for
that purpose.