### PR TITLE
Fix broken --cache-from due logging in after build

### DIFF
--- a/docker-build
+++ b/docker-build
@@ -14,27 +14,6 @@ fi
 branch_tag="$(echo -n "$BRANCH" | tr -c '[:alnum:]-._' '-')"
 tags=("$SHA" "$branch_tag" "${branch_tag}-${BUILD}" latest)
 
-# Run docker build
-echo "running docker build" >&2
-build_args=(
-	"--build-arg" "GIT_COMMIT=${SHA}"
-	"--build-arg" "GIT_BRANCH=${BRANCH}"
-
-	# Always include BuildKit inline cache when BuildKit is enabled, this
-	# allows --cache-from to work for multi-stage builds.
-	# BuildKit's default progress output is nice in interactive terminals but
-	# not so much in CI where we want simple sequential logs, so we also always
-	# set progress to plain with BuildKit.
-	"--build-arg" "BUILDKIT_INLINE_CACHE=1"
-)
-for tag in "${tags[@]}"; do
-	build_args+=("--cache-from" "${REPO}:${tag}")
-	build_args+=("-t" "${REPO}:${tag}")
-done
-set -x
-docker build "${build_args[@]}" "$@" "${DOCKER_BUILD_PATH:-.}"
-set +x
-
 # Create ECR repository if it doesn't already exist.
 echo "ensuring ECR repository exists with the right lifecycle policy" >&2
 aws ecr describe-repositories \
@@ -60,6 +39,27 @@ printenv DOCKER_PASS | docker login --username "$DOCKER_USER" --password-stdin
 echo "logging in to ECR" >&2
 aws ecr get-login-password --region "$AWS_REGION" \
 	| docker login --username AWS --password-stdin "$AWS_ECR_ACCOUNT_URL"
+
+# Run docker build
+echo "running docker build" >&2
+build_args=(
+	"--build-arg" "GIT_COMMIT=${SHA}"
+	"--build-arg" "GIT_BRANCH=${BRANCH}"
+
+	# Always include BuildKit inline cache when BuildKit is enabled, this
+	# allows --cache-from to work for multi-stage builds.
+	# BuildKit's default progress output is nice in interactive terminals but
+	# not so much in CI where we want simple sequential logs, so we also always
+	# set progress to plain with BuildKit.
+	"--build-arg" "BUILDKIT_INLINE_CACHE=1"
+)
+for tag in "${tags[@]}"; do
+	build_args+=("--cache-from" "${REPO}:${tag}")
+	build_args+=("-t" "${REPO}:${tag}")
+done
+set -x
+docker build "${build_args[@]}" "$@" "${DOCKER_BUILD_PATH:-.}"
+set +x
 
 # Push images
 registries=("docker.io" "$AWS_ECR_ACCOUNT_URL")


### PR DESCRIPTION
We need to authenticate with Docker Hub and ECR _first_ so that we can leverage cache from private repos.