### PR TITLE
Increase docker resource_class to xlarge

### DIFF
--- a/orb.tmpl.yml
+++ b/orb.tmpl.yml
@@ -19,8 +19,13 @@ jobs:
           Additional arguments to be passed to "docker build", e.g. "--target my-stage --build-arg FOO=42".
         type: "string"
         default: ""
+      resource-class:
+        description: Docker executor resource class.
+        type: "string"
+        default: "medium"
     docker:
       - image: "{{docker_image}}"
+    resource_class: << parameters.resource-class >>
     environment:
       DOCKER_BUILDKIT: "1"
       BUILDKIT_PROGRESS: "plain"


### PR DESCRIPTION
The default appears to be medium, which is only 2 cores. This increases the default for all orb users to 8 cores, which is almost always what we'd want.