### PR TITLE
Remove remote docker version requirement and use default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,8 +21,7 @@ jobs:
       BUILDKIT_PROGRESS: plain
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 20.10.18
+      - setup_remote_docker
       - run: apk --update add make shellcheck docker git
       - run:
           name: Install CircleCI CLI

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.18
+FROM docker:24-cli
 
 ENTRYPOINT ["/bin/bash"]
 

--- a/orb.tmpl.yml
+++ b/orb.tmpl.yml
@@ -34,8 +34,7 @@ jobs:
           condition: << parameters.checkout >>
           steps:
             - checkout
-      - setup_remote_docker:
-          version: 20.10.18
+      - setup_remote_docker
       - run:
           name: Build, tag, and push to Docker Hub and AWS ECR
           command: docker-build << parameters.build-args >>


### PR DESCRIPTION
This was only specified previously because the default version was not new enough to support the features we were using; now that 20.10.18 is being deprecated [1] we can switch back to the default (currently Docker 25).

[1] https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176