### PR TITLE
Update ECR lifecycle policy to cut costs

### DIFF
--- a/default-ecr-lifecycle-policy.json
+++ b/default-ecr-lifecycle-policy.json
@@ -7,7 +7,7 @@
         "tagStatus": "tagged",
         "tagPrefixList": ["master", "main"],
         "countType": "imageCountMoreThan",
-        "countNumber": 1000
+        "countNumber": 100
       },
       "action": {
         "type": "expire"
@@ -19,7 +19,20 @@
       "selection": {
         "tagStatus": "any",
         "countType": "imageCountMoreThan",
-        "countNumber": 5000
+        "countNumber": 100
+      },
+      "action": {
+        "type": "expire"
+      }
+    },
+    {
+      "rulePriority": 3,
+      "description": "Only retain non-master/main images less than 90 days old",
+      "selection": {
+        "tagStatus": "any",
+        "countType": "sinceImagePushed",
+        "countUnit": "days",
+        "countNumber": 90
       },
       "action": {
         "type": "expire"


### PR DESCRIPTION
This retains only 100 images with master/main prefixed tags, 100 of any other tag, and any other images less than 90 days old.

I haven't fully thought through the implications of changing this on every ECR repo we have, but putting up a PR anyway to start a discussion.

For reference, we're spending roughly $670/mo on ECR storage in the remind AWS accounts.

To roll this out, we'll have to cut a new `v1.x.y` release and then trigger all the CircleCI pipelines that use the orb, and they should all update the lifecycle policy for their ECR repos.